### PR TITLE
Refactor code base for update followup schedule and database

### DIFF
--- a/pyfinder/findermanager.py
+++ b/pyfinder/findermanager.py
@@ -187,7 +187,7 @@ class FinDerManager:
 
         if delay_minutes is not None:
             # e.g., "t00010" for 10 min
-            appendix = f"t{delay_minutes:05d}"  
+            appendix = f"t{int(delay_minutes):05d}"  
         else:
             # fallback if delay is undefined
             appendix = "t00000"  

--- a/pyfinder/services/database.py
+++ b/pyfinder/services/database.py
@@ -32,12 +32,16 @@ class ThreadSafeDB:
                 last_update_time TEXT,
                 last_query_time TEXT,
                 next_query_time TEXT,
+                current_delay_time REAL DEFAULT NULL,
+                next_delay_time REAL DEFAULT NULL,
                 retry_count INTEGER DEFAULT 0,
                 update_attempt_count INTEGER DEFAULT 0,
                 expiration_time TEXT,
                 priority INTEGER DEFAULT 1,
                 last_error TEXT DEFAULT NULL,
                 last_data_hash TEXT DEFAULT NULL,
+                last_data_snapshot TEXT DEFAULT NULL,
+                emsc_alert_json TEXT DEFAULT NULL,
                 last_modified TEXT DEFAULT (DATETIME('now')),
                 PRIMARY KEY (event_id, service)
             )
@@ -48,7 +52,9 @@ class ThreadSafeDB:
         """Calculate a hash of the provided data for change detection."""
         return hashlib.sha256(data.encode('utf-8')).hexdigest()
 
-    def add_event(self, event_id, services, origin_time, last_update_time, expiration_days=5):
+    def add_event(self, event_id, services, origin_time, last_update_time, expiration_days=5,
+                  current_delay_time=None, next_delay_time=None, emsc_alert_json=None, 
+                  next_query_time=None):
         """Add a new event to the database."""
         now = datetime.now()
         expiration_time = (now + timedelta(days=expiration_days)).isoformat()
@@ -58,10 +64,12 @@ class ThreadSafeDB:
                 INSERT OR IGNORE INTO event_tracker (
                     event_id, service, status, origin_time, last_update_time, 
                     last_query_time, next_query_time, retry_count, 
-                    update_attempt_count, expiration_time
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    update_attempt_count, expiration_time,
+                    current_delay_time, next_delay_time, emsc_alert_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (event_id, service, "Pending", origin_time, last_update_time, None, 
-                      now.isoformat(), 0, 0, expiration_time))
+                      next_query_time or now.isoformat(), 0, 0, expiration_time, 
+                      current_delay_time, next_delay_time, emsc_alert_json))
             self.conn.commit()
 
     def fetch_due_events(self, service=None, limit=10):
@@ -79,38 +87,31 @@ class ThreadSafeDB:
             self.cursor.execute(query, params)
             return self.cursor.fetchall()
 
-    def _update_event_status_locked(self, event_id, service, status, next_interval_minutes=30, increment_attempt=True):
+    def _update_event_status_locked(self, event_id, service, status, next_query_time):
         """Update the status of an event and schedule the next query time (requires lock to be held)."""
         now = datetime.now()
-        next_query_time = (now + timedelta(minutes=next_interval_minutes)).isoformat()
-        if increment_attempt:
-            self.cursor.execute('''
+        self.cursor.execute('''
             UPDATE event_tracker
             SET status = ?, last_query_time = ?, next_query_time = ?, 
-                update_attempt_count = update_attempt_count + 1, 
+                update_attempt_count = update_attempt_count + 1,
+                current_delay_time = NULL, next_delay_time = NULL,
                 last_modified = ?
-            WHERE event_id = ? AND service = ?
-            ''', (status, now.isoformat(), next_query_time, now.isoformat(), event_id, service))
-        else:
-            self.cursor.execute('''
-            UPDATE event_tracker
-            SET status = ?, last_query_time = ?, next_query_time = ?, last_modified = ?
             WHERE event_id = ? AND service = ?
             ''', (status, now.isoformat(), next_query_time, now.isoformat(), event_id, service))
         self.conn.commit()
 
-    def update_event_status(self, event_id, service, status, next_interval_minutes=30, increment_attempt=True):
+    def update_event_status(self, event_id, service, status, next_query_time):
         """Public method to update event status with locking."""
         if not self._lock.acquire(timeout=10):  # Timeout to prevent indefinite locking
             raise TimeoutError("Database lock acquisition timed out.")
         try:
-            self._update_event_status_locked(event_id, service, status, next_interval_minutes, increment_attempt)
+            self._update_event_status_locked(event_id, service, status, next_query_time)
         finally:
             self._lock.release()
 
     
     def mark_event_completed(self, event_id, service):
-        """Mark an event as completed."""
+        """Deprecated: use `upsert_event_state` to mark status."""
         now = datetime.now().isoformat()
         with self._lock:
             self.cursor.execute('''
@@ -121,7 +122,7 @@ class ThreadSafeDB:
             self.conn.commit()
 
     def retry_failed_events(self, max_retries=5):
-        """Reset the status of failed events for retry, if retry_count < max_retries."""
+        """Deprecated: retry logic should be handled externally."""
         now = datetime.now()
         with self._lock:
             self.cursor.execute('''
@@ -132,13 +133,14 @@ class ThreadSafeDB:
             self.conn.commit()
 
     def log_query_error(self, event_id, service, error_message, next_interval_minutes=30):
-        """Log an error message for a failed query and increment retry_count."""
+        """Deprecated: use `upsert_event_state` instead."""
         now = datetime.now()
         next_query_time = (now + timedelta(minutes=next_interval_minutes)).isoformat()
         with self._lock:
             self.cursor.execute('''
             UPDATE event_tracker
             SET status = "Failed", last_error = ?, retry_count = retry_count + 1, 
+                current_delay_time = NULL, next_delay_time = NULL,
                 last_modified = ?, next_query_time = ?
             WHERE event_id = ? AND service = ?
             ''', (error_message, now.isoformat(), next_query_time, event_id, service))
@@ -163,46 +165,41 @@ class ThreadSafeDB:
         with self._lock:
             self.cursor.execute('''
             SELECT event_id, service, origin_time, last_query_time, next_query_time, status, 
-                retry_count, update_attempt_count, expiration_time
+                retry_count, update_attempt_count, expiration_time,
+                current_delay_time, next_delay_time, emsc_alert_json, last_data_snapshot
             FROM event_tracker
             WHERE event_id = ? AND service = ?
             ''', (event_id, service))
             row = self.cursor.fetchone()
             if row:
                 keys = ["event_id", "service", "origin_time", "last_query_time", "next_query_time", "status",
-                        "retry_count", "update_attempt_count", "expiration_time"]
+                        "retry_count", "update_attempt_count", "expiration_time",
+                        "current_delay_time", "next_delay_time", "emsc_alert_json", "last_data_snapshot"]
                 return dict(zip(keys, row))
             return None
 
-# Example Tests
-if __name__ == "__main__":
-    db = ThreadSafeDB()
+    def upsert_event_state(self, event_id, service, **kwargs):
+        """
+        Insert or update a full or partial event state.
+        Only updates fields that are explicitly provided.
+        """
+        now = datetime.now().isoformat()
+        kwargs["last_modified"] = now
 
-    # Add events
-    db.add_event("12345", ["EMSC", "RRSM"], expiration_days=7)
-    db.add_event("67890", ["ESM"], expiration_days=5)
+        columns = ["event_id", "service"]
+        values = [event_id, service]
+        update_clause = []
 
-    # Simulate fetching and checking data
-    new_data = '{"magnitude": 4.5, "location": "XYZ"}'
-    db.update_or_skip_event("12345", "EMSC", new_data)
+        for key, value in kwargs.items():
+            columns.append(key)
+            values.append(value)
+            update_clause.append(f"{key}=excluded.{key}")
 
-    # Simulate unchanged data
-    db.update_or_skip_event("12345", "EMSC", new_data)  # Should skip
-
-    # Simulate error logging
-    try:
-        raise Exception("Service unavailable")
-    except Exception as e:
-        db.log_query_error("12345", "EMSC", str(e))
-
-    # Retry failed events
-    db.retry_failed_events()
-
-    # Fetch pending events
-    pending = db.fetch_due_events()
-    print("Pending events:", pending)
-
-    # Cleanup expired events
-    db.cleanup_expired_events()
-
-    db.close()
+        with self._lock:
+            self.cursor.execute(f'''
+                INSERT INTO event_tracker ({", ".join(columns)})
+                VALUES ({", ".join("?" for _ in columns)})
+                ON CONFLICT(event_id, service) DO UPDATE SET
+                    {", ".join(update_clause)}
+            ''', values)
+            self.conn.commit()

--- a/pyfinder/services/database.py
+++ b/pyfinder/services/database.py
@@ -1,11 +1,24 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python
-""" Database utility for tracking events and their query status. """
+""" 
+Database utility for tracking events and their query status. This module normally 
+should not be used directly, but rather through the services.eventtracker.EventTracker 
+class, which provides a higher-level interface for database operations related to event 
+updates and follow-ups.
+"""
 
 import sqlite3
 import threading
 import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+
+def safe_parse_iso(timestamp: str):
+    try:
+        return datetime.fromisoformat(timestamp)
+    except ValueError:
+        return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+
 
 class ThreadSafeDB:
     _lock = threading.Lock()
@@ -23,6 +36,7 @@ class ThreadSafeDB:
     def _create_table(self):
         """Create the event tracking table if it doesn't exist."""
         with self._lock:
+            # All timestamps are stored as UTC ISO 8601 strings
             self.cursor.execute('''
             CREATE TABLE IF NOT EXISTS event_tracker (
                 event_id TEXT,
@@ -56,8 +70,8 @@ class ThreadSafeDB:
                   current_delay_time=None, next_delay_time=None, emsc_alert_json=None, 
                   next_query_time=None):
         """Add a new event to the database."""
-        now = datetime.now()
-        expiration_time = (now + timedelta(days=expiration_days)).isoformat()
+        now = datetime.now(timezone.utc)
+        expiration_time = (now + timedelta(days=expiration_days)).isoformat(timespec='seconds')
         with self._lock:
             for service in services:
                 self.cursor.execute('''
@@ -68,13 +82,13 @@ class ThreadSafeDB:
                     current_delay_time, next_delay_time, emsc_alert_json
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (event_id, service, "Pending", origin_time, last_update_time, None, 
-                      next_query_time or now.isoformat(), 0, 0, expiration_time, 
+                      next_query_time or now.isoformat(timespec='seconds'), 0, 0, expiration_time, 
                       current_delay_time, next_delay_time, emsc_alert_json))
             self.conn.commit()
 
     def fetch_due_events(self, service=None, limit=10):
         """Fetch events that are due for querying, optionally filtered by service."""
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
         query = '''SELECT event_id, service FROM event_tracker 
                    WHERE next_query_time <= ? AND status IN ("Pending", "Failed")'''
         params = [now]
@@ -87,68 +101,19 @@ class ThreadSafeDB:
             self.cursor.execute(query, params)
             return self.cursor.fetchall()
 
-    def _update_event_status_locked(self, event_id, service, status, next_query_time):
-        """Update the status of an event and schedule the next query time (requires lock to be held)."""
-        now = datetime.now()
-        self.cursor.execute('''
-            UPDATE event_tracker
-            SET status = ?, last_query_time = ?, next_query_time = ?, 
-                update_attempt_count = update_attempt_count + 1,
-                current_delay_time = NULL, next_delay_time = NULL,
-                last_modified = ?
-            WHERE event_id = ? AND service = ?
-            ''', (status, now.isoformat(), next_query_time, now.isoformat(), event_id, service))
-        self.conn.commit()
-
-    def update_event_status(self, event_id, service, status, next_query_time):
-        """Public method to update event status with locking."""
-        if not self._lock.acquire(timeout=10):  # Timeout to prevent indefinite locking
-            raise TimeoutError("Database lock acquisition timed out.")
-        try:
-            self._update_event_status_locked(event_id, service, status, next_query_time)
-        finally:
-            self._lock.release()
-
-    
     def mark_event_completed(self, event_id, service):
-        """Deprecated: use `upsert_event_state` to mark status."""
-        now = datetime.now().isoformat()
-        with self._lock:
-            self.cursor.execute('''
-            UPDATE event_tracker
-            SET status = "Completed", last_query_time = ?, last_modified = ?
-            WHERE event_id = ? AND service = ?
-            ''', (now, now, event_id, service))
-            self.conn.commit()
-
-    def retry_failed_events(self, max_retries=5):
-        """Deprecated: retry logic should be handled externally."""
-        now = datetime.now()
-        with self._lock:
-            self.cursor.execute('''
-            UPDATE event_tracker
-            SET status = "Pending", next_query_time = ?, retry_count = retry_count + 1, last_modified = ?
-            WHERE status = "Failed" AND retry_count < ?
-            ''', (now.isoformat(), now.isoformat(), max_retries))
-            self.conn.commit()
-
-    def log_query_error(self, event_id, service, error_message, next_interval_minutes=30):
-        """Deprecated: use `upsert_event_state` instead."""
-        now = datetime.now()
-        next_query_time = (now + timedelta(minutes=next_interval_minutes)).isoformat()
-        with self._lock:
-            self.cursor.execute('''
-            UPDATE event_tracker
-            SET status = "Failed", last_error = ?, retry_count = retry_count + 1, 
-                current_delay_time = NULL, next_delay_time = NULL,
-                last_modified = ?, next_query_time = ?
-            WHERE event_id = ? AND service = ?
-            ''', (error_message, now.isoformat(), next_query_time, event_id, service))
-            self.conn.commit()
+        """Mark an event as completed with timestamp."""
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
+        self._update_event_fields(
+            event_id,
+            service,
+            status="Completed",
+            last_query_time=now
+        )
 
     def cleanup_expired_events(self):
         """Remove or mark expired events as inactive."""
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
         with self._lock:
             self.cursor.execute('''
             DELETE FROM event_tracker
@@ -183,7 +148,7 @@ class ThreadSafeDB:
         Insert or update a full or partial event state.
         Only updates fields that are explicitly provided.
         """
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
         kwargs["last_modified"] = now
 
         columns = ["event_id", "service"]
@@ -201,5 +166,49 @@ class ThreadSafeDB:
                 VALUES ({", ".join("?" for _ in columns)})
                 ON CONFLICT(event_id, service) DO UPDATE SET
                     {", ".join(update_clause)}
+            ''', values)
+            self.conn.commit()
+
+    def get_event(self, event_id, service):
+        """Retrieve full metadata for a specific event and service."""
+        return self.get_event_meta(event_id, service)
+
+    def defer_event(self, event_id, service, minutes=10):
+        """Postpone the next query time by N minutes."""
+        meta = self.get_event(event_id, service)
+        if not meta or not meta.get("next_query_time"):
+            return
+        current_time = safe_parse_iso(meta["next_query_time"])
+        new_time = current_time + timedelta(minutes=minutes)
+        self.upsert_event_state(event_id, service, next_query_time=new_time.isoformat(timespec='seconds'))
+
+    def query_by_priority(self, min_priority=1):
+        """Get events with priority greater than or equal to a given value."""
+        with self._lock:
+            self.cursor.execute('''
+                SELECT event_id, service, priority, next_query_time
+                FROM event_tracker
+                WHERE priority >= ?
+                ORDER BY priority DESC, next_query_time ASC
+            ''', (min_priority,))
+            return self.cursor.fetchall()
+
+    def _update_event_fields(self, event_id, service, **kwargs):
+        """
+        Update specific fields of an event.
+        """
+        if not kwargs:
+            return
+        columns = []
+        values = []
+        for key, value in kwargs.items():
+            columns.append(f"{key} = ?")
+            values.append(value)
+        values.extend([event_id, service])
+        with self._lock:
+            self.cursor.execute(f'''
+                UPDATE event_tracker
+                SET {", ".join(columns)}
+                WHERE event_id = ? AND service = ?
             ''', values)
             self.conn.commit()

--- a/pyfinder/services/eventtracker.py
+++ b/pyfinder/services/eventtracker.py
@@ -70,14 +70,14 @@ class EventTracker:
         """Mark event as completed with timestamp."""
         self._db.mark_event_completed(event_id, service, current_delay_time)
         now = datetime.now(timezone.utc).isoformat(timespec='seconds')
-        self._db_update_event_fields(event_id, service, current_delay_time, **{
+        self.db_update_event_fields(event_id, service, current_delay_time, **{
             self.Field.last_query_time: now
         })
 
     def mark_as_processing(self, event_id, service, current_delay_time):
         """Mark an event as currently being processed."""
         now = datetime.now(timezone.utc).isoformat(timespec='seconds')
-        self._db_update_event_fields(event_id, service, current_delay_time, **{
+        self.db_update_event_fields(event_id, service, current_delay_time, **{
             self.Field.status: STATUS_PROCESSING,
             self.Field.last_query_time: now
         })
@@ -90,7 +90,7 @@ class EventTracker:
         """Close database connection."""
         self._db.close()
 
-    def _db_update_event_fields(self, event_id, service, current_delay_time, **fields):
+    def db_update_event_fields(self, event_id, service, current_delay_time, **fields):
         """Update selected fields for an event (status, next_query_time, etc.)."""
         self._db._update_event_fields(event_id, service, current_delay_time, **fields)
 
@@ -115,7 +115,7 @@ class EventTracker:
     def mark_failed(self, event_id, service, current_delay_time, error_message):
         """Mark an event as failed and log the error message."""
         now = datetime.now(timezone.utc).isoformat(timespec='seconds')
-        self._db_update_event_fields(event_id, service, current_delay_time, **{
+        self.db_update_event_fields(event_id, service, current_delay_time, **{
             self.Field.status: STATUS_INCOMPLETE,
             self.Field.last_error: error_message,
             self.Field.last_query_time: now
@@ -127,7 +127,7 @@ class EventTracker:
         if not meta:
             return
         retry = (meta.get(self.Field.retry_count) or 0) + 1
-        self._db_update_event_fields(event_id, service, current_delay_time, **{
+        self.db_update_event_fields(event_id, service, current_delay_time, **{
             self.Field.retry_count: retry
         })
 
@@ -213,7 +213,7 @@ class EventTracker:
                 meta[self.Field.event_id] == event_id and
                 meta[self.Field.service] == service
             ):
-                self._db_update_event_fields(
+                self.db_update_event_fields(
                     event_id=event_id,
                     service=service,
                     current_delay_time=meta[self.Field.current_delay_time],
@@ -230,6 +230,6 @@ class EventTracker:
         current_time = parse_normalized_iso8601(meta[self.Field.next_query_time])
         new_time = current_time + timedelta(minutes=minutes)
 
-        self._db_update_event_fields(event_id, service, current_delay_time, **{
+        self.db_update_event_fields(event_id, service, current_delay_time, **{
             self.Field.next_query_time: new_time.isoformat(timespec='seconds')
         })

--- a/pyfinder/services/eventtracker.py
+++ b/pyfinder/services/eventtracker.py
@@ -68,11 +68,17 @@ class EventTracker:
     def mark_completed(self, event_id, service, current_delay_time):
         """Mark event as completed with timestamp."""
         self._db.mark_event_completed(event_id, service, current_delay_time)
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
+        self._db_update_event_fields(event_id, service, current_delay_time, **{
+            self.Field.last_query_time: now
+        })
 
     def mark_as_processing(self, event_id, service, current_delay_time):
         """Mark an event as currently being processed."""
+        now = datetime.now(timezone.utc).isoformat(timespec='seconds')
         self._db_update_event_fields(event_id, service, current_delay_time, **{
-            self.Field.status: STATUS_PROCESSING
+            self.Field.status: STATUS_PROCESSING,
+            self.Field.last_query_time: now
         })
 
     def cleanup_expired(self):

--- a/pyfinder/services/eventtracker.py
+++ b/pyfinder/services/eventtracker.py
@@ -10,13 +10,7 @@ from pyfinder.services.database import ThreadSafeDB
 from datetime import datetime, timedelta, timezone
 import logging
 from utils.customlogger import file_logger
-
-
-def safe_parse_iso(timestamp: str):
-    try:
-        return datetime.fromisoformat(timestamp)
-    except ValueError:
-        return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+from utils.timeutils import parse_normalized_iso8601
 
 
 class EventTracker:
@@ -31,7 +25,6 @@ class EventTracker:
         current_delay_time = "current_delay_time"
         next_delay_time = "next_delay_time"
         retry_count = "retry_count"
-        update_attempt_count = "update_attempt_count"
         expiration_time = "expiration_time"
         priority = "priority"
         last_error = "last_error"
@@ -44,10 +37,14 @@ class EventTracker:
         self.db = ThreadSafeDB(db_path)
         logger = logger or logging.getLogger("pyfinder")
         self.set_logger(logger)
+        # Attach logger to DB for warnings (conflict inserts)
+        self.db.set_logger(self.logger)
 
     def set_logger(self, logger=None):
-        """Set a logger for the EventTracker."""
+        """Set a logger for the EventTracker and pass it to DB."""
         self.logger = logger
+        if hasattr(self, "db"):
+            self.db.set_logger(logger)
 
     def initialize_event(self, event_id, services, origin_time, last_update_time, expiration_days=5):
         """Initialize a new event for one or more services."""
@@ -59,9 +56,9 @@ class EventTracker:
             last_update_time=last_update_time
             )
 
-    def get_due_events(self, service, limit=10):
+    def get_due_events(self, service):
         """Fetch events that are due for querying for a given service."""
-        return self.db.fetch_due_events(service=service, limit=limit)
+        return self.db.fetch_due_events(service=service)
 
     def mark_completed(self, event_id, service):
         """Mark event as completed if data changed; otherwise defer."""
@@ -108,7 +105,6 @@ class EventTracker:
                     self.Field.last_query_time: old_meta[self.Field.last_query_time],
                     self.Field.next_query_time: old_meta[self.Field.next_query_time],
                     self.Field.retry_count: old_meta[self.Field.retry_count],
-                    self.Field.update_attempt_count: old_meta[self.Field.update_attempt_count],
                     self.Field.expiration_time: old_meta[self.Field.expiration_time],
                     self.Field.priority: 1,
                     self.Field.last_error: None,
@@ -125,19 +121,19 @@ class EventTracker:
         """Retrieve all pending or failed events across all services."""
         return self.db.get_all_pending_events()
 
-    def get_event(self, event_id, service):
+    def get_event_meta(self, event_id, service):
         """Retrieve full metadata for a specific event and service."""
         return self.db.get_event_meta(event_id, service)
 
     def defer_event(self, event_id, service, minutes=10):
         """Postpone the next query time by N minutes."""
-        meta = self.get_event(event_id, service)
+        meta = self.get_event_meta(event_id, service)
         if not meta or not meta.get(self.Field.next_query_time):
             return
-        current_time = safe_parse_iso(meta[self.Field.next_query_time])
+        current_time = parse_normalized_iso8601(meta[self.Field.next_query_time])
         new_time = current_time + timedelta(minutes=minutes)
         self._update_event_fields(event_id, service, **{
-            self.Field.next_query_time: new_time.isoformat(timespec='seconds')
+            self.Field.next_query_time: new_time.isoformat(timespec='microseconds')
         })
 
     def mark_failed(self, event_id, service, error_message):
@@ -151,7 +147,7 @@ class EventTracker:
 
     def increment_retry_count(self, event_id, service):
         """Increment the retry count for a given event and service."""
-        meta = self.get_event(event_id, service)
+        meta = self.get_event_meta(event_id, service)
         if not meta:
             return
         retry = (meta.get(self.Field.retry_count) or 0) + 1
@@ -161,19 +157,12 @@ class EventTracker:
 
     def query_by_priority(self, min_priority=1):
         """Get events with priority greater than or equal to a given value."""
-        with self.db._lock:
-            self.db.cursor.execute('''
-                SELECT event_id, service, priority, next_query_time
-                FROM event_tracker
-                WHERE priority >= ?
-                ORDER BY priority DESC, next_query_time ASC
-            ''', (min_priority,))
-            return self.db.cursor.fetchall()
+        return self.db.query_by_priority(min_priority)
         
-    def register_service_schedule(
+    def register_update_schedule(
             self, event_id, service, origin_time, last_update_time,
             current_delay_time=None, next_delay_time=None,
-            next_query_time=None, emsc_alert_json=None, expiration_days=5):
+            next_query_time=None, emsc_alert_json=None, expiration_days=5, **kwargs):
         """Schedule or update a service update for a specific event."""
         expiration_time = (datetime.now(timezone.utc) + timedelta(days=expiration_days)).isoformat(timespec='seconds')
         self.db.upsert_event_state(
@@ -187,6 +176,55 @@ class EventTracker:
                 self.Field.current_delay_time: current_delay_time,
                 self.Field.next_delay_time: next_delay_time,
                 self.Field.emsc_alert_json: emsc_alert_json,
-                self.Field.expiration_time: expiration_time
+                self.Field.expiration_time: expiration_time,
+                **kwargs,
             }
         )
+
+    def batch_register_from_policy(
+        self, event_id, policy, origin_time, last_update_time,
+        emsc_alert_json=None, expiration_days=5, **kwargs):
+        """
+        Register multiple scheduled service updates using a policy instance.
+
+        The policy instance must define:
+        - policy.service_name (str)
+        - policy.schedule_delays (List[float]) in minutes
+
+        Each delay will create a separate row entry with a calculated next_query_time.
+        """
+        now = datetime.now(timezone.utc)
+        delays = policy.QUERY_SCHEDULE_MINUTES
+        for i, delay in enumerate(delays):
+            print(f"Registering event {event_id} for service {policy.service_name} with delay {delay} minutes")
+            
+            next_delay = delays[i + 1] if i + 1 < len(delays) else None
+            next_query_time = (now + timedelta(minutes=delay)).isoformat(timespec='seconds')
+            self.register_update_schedule(
+                event_id=event_id,
+                service=policy.service_name,
+                origin_time=origin_time,
+                last_update_time=last_update_time,
+                current_delay_time=delay,
+                next_delay_time=next_delay,
+                next_query_time=next_query_time,
+                emsc_alert_json=emsc_alert_json,
+                expiration_days=expiration_days,
+                **kwargs
+            )
+    
+    def refresh_metadata_after_emsc_update(
+        self, event_id, service, new_last_update_time,
+        origin_time=None, emsc_alert_json=None
+    ):
+        """Update EMSC-related metadata without altering the schedule or retry status."""
+        fields_to_update = {
+            self.Field.last_update_time: new_last_update_time,
+            self.Field.last_modified: datetime.now(timezone.utc).isoformat(timespec='seconds'),
+        }
+        if origin_time:
+            fields_to_update[self.Field.origin_time] = origin_time
+        if emsc_alert_json:
+            fields_to_update[self.Field.emsc_alert_json] = emsc_alert_json
+
+        self._update_event_fields(event_id, service, **fields_to_update)

--- a/pyfinder/services/querypolicy.py
+++ b/pyfinder/services/querypolicy.py
@@ -7,25 +7,7 @@ time intervals.
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 import math
-
-def normalize_iso8601(ts: str) -> datetime:
-    tz = None
-    if ts.endswith("Z"):
-        ts = ts[:-1]
-        tz = timezone.utc
-
-    if "." in ts:
-        date_part, frac = ts.split(".")
-        if "+" in frac or "-" in frac:  # timezone present
-            frac_part, tz_part = frac[:-6], frac[-6:]
-            frac_part = (frac_part + "000000")[:6]
-            ts = f"{date_part}.{frac_part}{tz_part}"
-        else:
-            frac = (frac + "000000")[:6]
-            ts = f"{date_part}.{frac}"
-
-    dt = datetime.fromisoformat(ts)
-    return dt.replace(tzinfo=tz) if tz else dt
+from utils.timeutils import normalize_iso8601
 
 class AbstractPolicy(ABC):
     @abstractmethod
@@ -68,6 +50,10 @@ class RRSMQueryPolicy(AbstractPolicy):
     
     # allow query within some minutes window
     ALLOWED_DRIFT_MINUTES = 1  
+
+    # The service name
+    service_name = "RRSM"
+
 
     def should_query(self, event_meta):
         """Return True if current time is within an allowed window."""
@@ -142,6 +128,7 @@ class RRSMQueryPolicy(AbstractPolicy):
 class ESMQueryPolicy(AbstractPolicy):
     QUERY_SCHEDULE_MINUTES = []
     ALLOWED_DRIFT_MINUTES = 1
+    service_name = "ESM"
 
     def should_query(self, event_meta):
         return False, "Dummy policy: ESM query not implemented"
@@ -165,6 +152,7 @@ class ESMQueryPolicy(AbstractPolicy):
 class EMSCQueryPolicy(AbstractPolicy):
     QUERY_SCHEDULE_MINUTES = []
     ALLOWED_DRIFT_MINUTES = 1
+    service_name = "EMSC"
 
     def should_query(self, event_meta):
         return False, "Dummy policy: EMSC query not implemented"

--- a/pyfinder/services/scheduler.py
+++ b/pyfinder/services/scheduler.py
@@ -106,6 +106,7 @@ class FollowUpScheduler:
                 "last_query_time": str(event_meta.get(EventTracker.Field.last_query_time)),
                 "minutes_until_next_update": delay,
                 "current_delay": event_meta.get(EventTracker.Field.current_delay_time),
+                "region": event_meta.get(EventTracker.Field.region),
             }
 
             delay_val = event_meta[EventTracker.Field.current_delay_time]

--- a/pyfinder/services/scheduler.py
+++ b/pyfinder/services/scheduler.py
@@ -196,7 +196,8 @@ class FollowUpScheduler:
 
         try:
             while True:
-                self.run_once()
+                # ONLY FOR DEBUGGING: Uncomment the next line to run once
+                # self.run_once()
                 time.sleep(interval_seconds)
         except KeyboardInterrupt:
             self.shutdown()

--- a/pyfinder/services/scheduler.py
+++ b/pyfinder/services/scheduler.py
@@ -112,15 +112,8 @@ class FollowUpScheduler:
             self.logger.info(f"FinDerManager run completed for event {event_id} with this outcome: {success}.")
             
             if success:
-                # If FinDerManager run was successful, check if the event is still valid
-                if policy.is_terminal(event_meta):
-                    # If the event is terminal, mark it as completed
-                    self.tracker.mark_completed(event_id, service)
-                    self.logger.info(f"Event {event_id} completed for service {service}.")
-                else:
-                    # Event is not terminal, keep the pending status and schedule the next query
-                    self.tracker.update_status(event_id, service, "Pending", next_minutes=delay)
-                    self.logger.info(f"Event {event_id} scheduled for next query in {delay} minutes.")
+                self.tracker.mark_completed(event_id, service)
+                self.logger.info(f"Event {event_id} marked completed for delay {event_meta.get('current_delay_time')} minutes for service {service}.")
             
             else:
                 # If FinDerManager run failed, check if the event is still valid
@@ -163,7 +156,7 @@ class FollowUpScheduler:
             return
 
         self.logger.info(f"Due events fetched: {len(due_events)}")
-        self.logger.info(f"Due events: {due_events}")
+        self.logger.info(f"Due events: {[(e[0], e[1]) for e in due_events]}")
 
         for event_id, service in due_events:
             # Mark the event as processing so that it is not fecthed again in the next

--- a/pyfinder/services/seismiclistener.py
+++ b/pyfinder/services/seismiclistener.py
@@ -94,8 +94,7 @@ def myprocessing(message, target_regions=None, min_magnitude=0):
         else:
             logger.info(f"|- Decision KEEP: Event {info['unid']} is in the target regions: {target_regions}")
 
-        # if not is_magnitude_above_threshold(info, min_magnitude):
-        if not is_magnitude_above_threshold(info, 0.5):
+        if not is_magnitude_above_threshold(info, min_magnitude):
             logger.info(f"|- Decision SKIP: Event {info['unid']} has magnitude {info['mag']} below threshold, skipping...")
             return
         else:

--- a/pyfinder/services/seismiclistener.py
+++ b/pyfinder/services/seismiclistener.py
@@ -15,6 +15,8 @@ import json
 from pyfinderconfig import pyfinderconfig
 from services.eventtracker import EventTracker
 from utils.customlogger import file_logger
+from services.querypolicy import RRSMQueryPolicy
+from utils.timeutils import parse_normalized_iso8601
 
 # WebSocket URI for Seismic Portal
 echo_uri = pyfinderconfig["seismic-portal-listener"]["echo-uri"]
@@ -30,6 +32,7 @@ logger = file_logger(
     overwrite=False,
     level=logging.DEBUG
 )
+
 # Database tracker for event management
 tracker = EventTracker("event_update_follow_up.db", logger=logger)
 
@@ -72,6 +75,11 @@ def myprocessing(message, target_regions=None, min_magnitude=0):
         info = data['data']['properties']
         info['action'] = data['action']
 
+        required_keys = ['unid', 'mag', 'time', 'lastupdate', 'flynn_region']
+        if not all(k in info for k in required_keys):
+            logger.warning(f"Malformed event received: missing keys in {info}")
+            return
+
         # Set default region filter if not provided
         if target_regions is None:
             target_regions = []
@@ -86,7 +94,8 @@ def myprocessing(message, target_regions=None, min_magnitude=0):
         else:
             logger.info(f"|- Decision KEEP: Event {info['unid']} is in the target regions: {target_regions}")
 
-        if not is_magnitude_above_threshold(info, min_magnitude):
+        # if not is_magnitude_above_threshold(info, min_magnitude):
+        if not is_magnitude_above_threshold(info, 0.5):
             logger.info(f"|- Decision SKIP: Event {info['unid']} has magnitude {info['mag']} below threshold, skipping...")
             return
         else:
@@ -97,23 +106,41 @@ def myprocessing(message, target_regions=None, min_magnitude=0):
         # Process new events
         if info['action'] == 'create':
             logger.info(f"New event: {info['unid']} at {info['time']}, Magnitude: {info['mag']}, Region: {info['flynn_region']}")
-            tracker.register_event(
+            logger.info(f"Starting to register event {info['unid']} with RRSM policy for future updates...")
+            policy = RRSMQueryPolicy()
+            origin_time = parse_normalized_iso8601(info['time']).isoformat(timespec='microseconds')
+            last_update_time = parse_normalized_iso8601(info['lastupdate']).isoformat(timespec='seconds')
+            try:
+                emsc_alert_json = json.dumps(info)
+            except Exception as e:
+                logger.warning(f"Could not serialize alert JSON for event {info['unid']}: {e}")
+                emsc_alert_json = None
+
+            tracker.batch_register_from_policy(
                 event_id=info['unid'],
-                services=["RRSM"],
-                last_update_time=info['lastupdate'],
-                origin_time=info['time'],
-                expiration_days=5
-            ) 
+                policy=policy,
+                origin_time=origin_time,
+                last_update_time=last_update_time,
+                emsc_alert_json=emsc_alert_json,
+            )
 
         # Process event updates
         elif info['action'] == 'update':
             logger.info(f"Updated event: {info['unid']} at {info['time']}, Magnitude: {info['mag']}, Region: {info['flynn_region']}")
-            tracker.register_event_after_emsc_update(
+            origin_time = parse_normalized_iso8601(info['time']).isoformat(timespec='microseconds')
+            last_update_time = parse_normalized_iso8601(info['lastupdate']).isoformat(timespec='seconds')
+            try:
+                emsc_alert_json = json.dumps(info)
+            except Exception as e:
+                logger.warning(f"Could not serialize alert JSON for event {info['unid']}: {e}")
+                emsc_alert_json = None
+
+            tracker.refresh_metadata_after_emsc_update(
                 event_id=info['unid'],
-                services=["RRSM"],
-                new_last_update_time=info['lastupdate'],
-                origin_time=info['time'],
-                expiration_days=5
+                service="RRSM",
+                new_last_update_time=last_update_time,
+                origin_time=origin_time,
+                emsc_alert_json=emsc_alert_json
             )
 
     except Exception:

--- a/pyfinder/services/seismiclistener.py
+++ b/pyfinder/services/seismiclistener.py
@@ -108,7 +108,7 @@ def myprocessing(message, target_regions=None, min_magnitude=0):
         # Process event updates
         elif info['action'] == 'update':
             logger.info(f"Updated event: {info['unid']} at {info['time']}, Magnitude: {info['mag']}, Region: {info['flynn_region']}")
-            tracker.register_event_after_update(
+            tracker.register_event_after_emsc_update(
                 event_id=info['unid'],
                 services=["RRSM"],
                 new_last_update_time=info['lastupdate'],

--- a/pyfinder/utils/timeutils.py
+++ b/pyfinder/utils/timeutils.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timezone
+
+
+def parse_normalized_iso8601(timestamp: str) -> datetime:
+    """Parses an ISO8601 timestamp string into a naive UTC datetime.
+    Handles cases like: '2025-05-28T18:00:04.22Z'
+    """
+    if timestamp.endswith("Z"):
+        timestamp = timestamp[:-1]  # Remove 'Z'
+
+    # Split fractional part and pad if necessary
+    try:
+        if "." in timestamp:
+            base, frac = timestamp.split(".")
+            frac = (frac + "000000")[:6]  # pad to 6 digits
+            timestamp = f"{base}.{frac}"
+        return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+    except Exception as e:
+        raise ValueError(f"Failed to parse ISO8601 string: {timestamp}") from e
+
+
+def normalize_iso8601(ts: str) -> datetime:
+    tz = None
+    if ts.endswith("Z"):
+        ts = ts[:-1]
+        tz = timezone.utc
+
+    if "." in ts:
+        date_part, frac = ts.split(".")
+        if "+" in frac or "-" in frac:  # timezone present
+            frac_part, tz_part = frac[:-6], frac[-6:]
+            frac_part = (frac_part + "000000")[:6]
+            ts = f"{date_part}.{frac_part}{tz_part}"
+        else:
+            frac = (frac + "000000")[:6]
+            ts = f"{date_part}.{frac}"
+
+    dt = datetime.fromisoformat(ts)
+    return dt.replace(tzinfo=tz) if tz else dt


### PR DESCRIPTION
This branch implements a one-row per update schedule and per service strategy rather than the previous single-row approach. The schedule plan is dumped into the database by the EMSC event listener; each update is then later picked by FollowUpScheduler when the time comes. The Policy logic still exists, but is not utilized heavily for decision making. 